### PR TITLE
foreman: Increase minion connection timeouts

### DIFF
--- a/cloud/foreman/foreman.go
+++ b/cloud/foreman/foreman.go
@@ -229,7 +229,7 @@ var newClient = newClientImpl
 
 func (cl clientImpl) getMinion() (pb.MinionConfig, error) {
 	c.Inc("Get Minion")
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
 	cfg, err := cl.GetMinionConfig(ctx, &pb.Request{})
 	if err != nil {
 		c.Inc("Get Minion Error")
@@ -241,7 +241,7 @@ func (cl clientImpl) getMinion() (pb.MinionConfig, error) {
 
 func (cl clientImpl) setMinion(cfg pb.MinionConfig) error {
 	c.Inc("Set Minion")
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
 	_, err := cl.SetMinionConfig(ctx, &cfg)
 	if err != nil {
 		c.Inc("Set Minion Error")


### PR DESCRIPTION
At scale (64 nodes) the foreman can take longer than 10 seconds to
reach all of it's minions.  There are some underlying inefficiencies
here that could be improved, but for now increasing the timeout seems
to help.