### PR TITLE
tests: Refactor the network test

### DIFF
--- a/integration-tester/tests/10-network/connection_test.go
+++ b/integration-tester/tests/10-network/connection_test.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/kelda/kelda/api/client"
 	"github.com/kelda/kelda/db"
-	"github.com/kelda/kelda/join"
 )
 
 type connectionTester struct {
@@ -52,61 +51,7 @@ func newConnectionTester(clnt client.Client) (connectionTester, error) {
 	}, nil
 }
 
-type pingResult struct {
-	target    string
-	reachable bool
-	err       error
-	cmdTime   commandTime
-}
-
-// We have to limit our parallelization because each `kelda exec` creates a new SSH login
-// session. Doing this quickly in parallel breaks system-logind
-// on the remote machine: https://github.com/systemd/systemd/issues/2925.
-// Furthermore, the concurrency limit cannot exceed the sshd MaxStartups setting,
-// or else the SSH connections may be randomly rejected.
-const execConcurrencyLimit = 5
-
-func (tester connectionTester) pingAll(container db.Container) []pingResult {
-	pingResultsChan := make(chan pingResult, len(tester.allHostnames))
-
-	// Create worker threads.
-	pingRequests := make(chan string, execConcurrencyLimit)
-	var wg sync.WaitGroup
-	for i := 0; i < execConcurrencyLimit; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for hostname := range pingRequests {
-				startTime := time.Now()
-				_, err := ping(container.BlueprintID, hostname)
-				pingResultsChan <- pingResult{
-					target:    hostname,
-					reachable: err == nil,
-					err:       err,
-					cmdTime:   commandTime{startTime, time.Now()},
-				}
-			}
-		}()
-	}
-
-	// Feed worker threads.
-	for _, hostname := range tester.allHostnames {
-		pingRequests <- hostname
-	}
-	close(pingRequests)
-	wg.Wait()
-	close(pingResultsChan)
-
-	// Collect results.
-	var pingResults []pingResult
-	for res := range pingResultsChan {
-		pingResults = append(pingResults, res)
-	}
-
-	return pingResults
-}
-
-func (tester connectionTester) test(container db.Container) (failures []error) {
+func (tester connectionTester) test(t *testing.T, container db.Container) {
 	// We should be able to ping ourselves.
 	expReachable := map[string]struct{}{
 		container.Hostname + ".q": {},
@@ -115,53 +60,30 @@ func (tester connectionTester) test(container db.Container) (failures []error) {
 		expReachable[dst+".q"] = struct{}{}
 	}
 
-	var expPings []pingResult
-	for _, ip := range tester.allHostnames {
-		_, reachable := expReachable[ip]
-		expPings = append(expPings, pingResult{
-			target:    ip,
-			reachable: reachable,
-		})
-	}
-	pingResults := tester.pingAll(container)
-	_, _, failuresIntf := join.HashJoin(pingSlice(expPings), pingSlice(pingResults),
-		ignoreErrorField, ignoreErrorField)
+	var wg sync.WaitGroup
 
-	for _, badIntf := range failuresIntf {
-		bad := badIntf.(pingResult)
-		var failure error
-		if bad.reachable {
-			failure = fmt.Errorf("(%s) could ping unauthorized container %s",
-				bad.cmdTime, bad.target)
-		} else {
-			failure = fmt.Errorf("(%s) couldn't ping authorized container "+
-				"%s: %s", bad.cmdTime, bad.target, bad.err)
+	test := func(hostname string) {
+		defer wg.Done()
+		startTime := time.Now()
+		_, err := keldaSSH(container.BlueprintID,
+			"ping", "-c", "3", "-W", "1", hostname)
+
+		reached := err == nil
+		if _, ok := expReachable[hostname]; ok {
+			if !reached {
+				t.Errorf("Failed to ping: %s %s -> %s. %s",
+					startTime, container.BlueprintID, hostname, err)
+			}
+		} else if reached {
+			t.Errorf("Unexpected ping success: %s %s -> %s",
+				startTime, container.BlueprintID, hostname)
 		}
-		failures = append(failures, failure)
 	}
 
-	return failures
-}
-
-func ignoreErrorField(pingResultIntf interface{}) interface{} {
-	return pingResult{
-		target:    pingResultIntf.(pingResult).target,
-		reachable: pingResultIntf.(pingResult).reachable,
+	for _, h := range tester.allHostnames {
+		wg.Add(1)
+		go test(h)
 	}
-}
 
-// ping `target` from within container `id` with 3 packets, with a timeout of
-// 1 second for each packet.
-func ping(id string, target string) (string, error) {
-	return keldaSSH(id, "ping", "-c", "3", "-W", "1", target)
-}
-
-type pingSlice []pingResult
-
-func (ps pingSlice) Get(ii int) interface{} {
-	return ps[ii]
-}
-
-func (ps pingSlice) Len() int {
-	return len(ps)
+	wg.Wait()
 }

--- a/integration-tester/tests/10-network/dns_test.go
+++ b/integration-tester/tests/10-network/dns_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/kelda/kelda/api/client"
@@ -49,65 +50,31 @@ func newDNSTester(clnt client.Client) (dnsTester, error) {
 	return dnsTester{hostnameIPMap}, nil
 }
 
-type lookupResult struct {
-	hostname string
-	ip       string
-	err      error
-	cmdTime  commandTime
-}
-
-// Resolve all hostnames on the container with the given BlueprintID. Parallelize
-// over the hostnames.
-func (tester dnsTester) lookupAll(container db.Container) []lookupResult {
-	lookupResultsChan := make(chan lookupResult, len(tester.hostnameIPMap))
-
-	// Create worker threads.
-	lookupRequests := make(chan string, execConcurrencyLimit)
+func (tester dnsTester) test(t *testing.T, container db.Container) {
 	var wg sync.WaitGroup
-	for i := 0; i < execConcurrencyLimit; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for hostname := range lookupRequests {
-				startTime := time.Now()
-				ip, err := lookup(container.BlueprintID, hostname)
-				lookupResultsChan <- lookupResult{hostname, ip, err,
-					commandTime{startTime, time.Now()}}
-			}
-		}()
-	}
 
-	// Feed worker threads.
-	for hostname := range tester.hostnameIPMap {
-		lookupRequests <- hostname
-	}
-	close(lookupRequests)
-	wg.Wait()
-	close(lookupResultsChan)
+	test := func(hostname string) {
+		defer wg.Done()
+		startTime := time.Now()
+		ip, err := lookup(container.BlueprintID, hostname)
 
-	// Collect results.
-	var results []lookupResult
-	for res := range lookupResultsChan {
-		results = append(results, res)
-	}
+		expIP := tester.hostnameIPMap[hostname]
+		if err == nil && expIP != anyIPAllowed && ip != expIP {
+			err = fmt.Errorf("wrong IP. expected %s, actual %s", expIP, ip)
+		}
 
-	return results
-}
-
-func (tester dnsTester) test(container db.Container) (failures []error) {
-	for _, l := range tester.lookupAll(container) {
-		expIP := tester.hostnameIPMap[l.hostname]
-		if l.err != nil {
-			failures = append(failures,
-				fmt.Errorf("(%s) lookup errored: %s", l.cmdTime, l.err))
-		} else if expIP != anyIPAllowed && l.ip != expIP {
-			failures = append(failures,
-				fmt.Errorf("(%s) expected %s, got %s",
-					l.cmdTime, expIP, l.ip))
+		if err != nil {
+			t.Errorf("DNS: %s %s -> %s: %s", startTime,
+				container.BlueprintID, hostname, err)
 		}
 	}
 
-	return failures
+	for h := range tester.hostnameIPMap {
+		wg.Add(1)
+		go test(h)
+	}
+
+	wg.Wait()
 }
 
 func lookup(id string, hostname string) (string, error) {


### PR DESCRIPTION
Before this patch, the network test code was extremely complicated and
slow.  SSH attempts tended to come in batches, causing the system to
either bottleneck on the concurrency limit, or waste time trying to
figure out what to do next.  This patch refactors the test and in the
process dramatically simplifies the code. It additionally causes SSH
executions to smooth out at a rate of once every 100ms which results
in a roughly 3x improvement in test time in my local environment.
This makes the network test much more palatable as a development tool.