### PR TITLE
network: Add support for address sets

### DIFF
--- a/blueprint/blueprint.go
+++ b/blueprint/blueprint.go
@@ -83,13 +83,13 @@ type LoadBalancer struct {
 	Hostnames []string `json:",omitempty"`
 }
 
-// A Connection allows the container with the `From` hostname to speak to the container
-// with the `To` hostname in ports in the range [MinPort, MaxPort]
+// A Connection allows any container whose hostname appears in `From` to speak with any
+// container whose hostname appears in `To` using ports in the range [MinPort, MaxPort]
 type Connection struct {
-	From    string `json:",omitempty"`
-	To      string `json:",omitempty"`
-	MinPort int    `json:",omitempty"`
-	MaxPort int    `json:",omitempty"`
+	From    []string `json:",omitempty"`
+	To      []string `json:",omitempty"`
+	MinPort int      `json:",omitempty"`
+	MaxPort int      `json:",omitempty"`
 }
 
 // A ConnectionSlice allows for slices of Collections to be used in joins

--- a/cli/command/inspect/graph.go
+++ b/cli/command/inspect/graph.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+
 	"github.com/kelda/kelda/blueprint"
 )
 
@@ -59,18 +60,22 @@ func (g Graph) GetConnections() []Edge {
 	return res
 }
 
-func (g *Graph) addConnection(from string, to string) error {
-	fromNode, ok := g.Nodes[from]
-	if !ok {
-		return fmt.Errorf("no node: %s", from)
-	}
+func (g *Graph) addConnection(fromSlice, toSlice []string) error {
+	for _, from := range fromSlice {
+		for _, to := range toSlice {
+			fromNode, ok := g.Nodes[from]
+			if !ok {
+				return fmt.Errorf("no node: %s", from)
+			}
 
-	toNode, ok := g.Nodes[to]
-	if !ok {
-		return fmt.Errorf("no node: %s", to)
-	}
+			toNode, ok := g.Nodes[to]
+			if !ok {
+				return fmt.Errorf("no node: %s", to)
+			}
 
-	fromNode.Connections[to] = toNode
+			fromNode.Connections[to] = toNode
+		}
+	}
 	return nil
 }
 

--- a/cli/command/inspect/inspect_test.go
+++ b/cli/command/inspect/inspect_test.go
@@ -63,8 +63,10 @@ func TestViz(t *testing.T) {
 			},
 		},
 		Connections: []blueprint.Connection{
-			{From: "a", To: "b", MinPort: 22, MaxPort: 22},
-			{From: "b", To: "c", MinPort: 22, MaxPort: 22},
+			{From: []string{"a"}, To: []string{"b"},
+				MinPort: 22, MaxPort: 22},
+			{From: []string{"b"}, To: []string{"c"},
+				MinPort: 22, MaxPort: 22},
 		},
 	}
 

--- a/cli/command/show.go
+++ b/cli/command/show.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kelda/kelda/blueprint"
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 )
 
 // An arbitrary length to truncate container commands to.
@@ -217,15 +218,18 @@ func writeContainers(fd io.Writer, containers []db.Container, machines []db.Mach
 func connToPorts(connections []db.Connection) map[string][]string {
 	hostnamePublicPorts := map[string][]string{}
 	for _, c := range connections {
-		if c.From != blueprint.PublicInternetLabel {
+		if !str.SliceContains(c.From, blueprint.PublicInternetLabel) {
 			continue
 		}
 
-		portStr := fmt.Sprintf("%d", c.MinPort)
-		if c.MinPort != c.MaxPort {
-			portStr += fmt.Sprintf("-%d", c.MaxPort)
+		for _, to := range c.To {
+			portStr := fmt.Sprintf("%d", c.MinPort)
+			if c.MinPort != c.MaxPort {
+				portStr += fmt.Sprintf("-%d", c.MaxPort)
+			}
+			hostnamePublicPorts[to] = append(hostnamePublicPorts[to],
+				portStr)
 		}
-		hostnamePublicPorts[c.To] = append(hostnamePublicPorts[c.To], portStr)
 	}
 	return hostnamePublicPorts
 }

--- a/cli/command/show_test.go
+++ b/cli/command/show_test.go
@@ -171,10 +171,14 @@ func TestContainerOutput(t *testing.T) {
 		{CloudID: "7", PrivateIP: ""},
 	}
 	connections := []db.Connection{
-		{ID: 1, From: "public", To: "frompublic1", MinPort: 80, MaxPort: 80},
-		{ID: 1, From: "public", To: "frompublic2", MinPort: 80, MaxPort: 80},
-		{ID: 1, From: "public", To: "frompublic3", MinPort: 80, MaxPort: 80},
-		{ID: 2, From: "notpublic", To: "frompublic1", MinPort: 100, MaxPort: 101},
+		{ID: 1, From: []string{"public"}, To: []string{"frompublic1"},
+			MinPort: 80, MaxPort: 80},
+		{ID: 1, From: []string{"public", "notpublic"},
+			To: []string{"frompublic2"}, MinPort: 80, MaxPort: 80},
+		{ID: 1, From: []string{"public"}, To: []string{"frompublic3"},
+			MinPort: 80, MaxPort: 80},
+		{ID: 2, From: []string{"notpublic", "frompublic2"},
+			To: []string{"frompublic1"}, MinPort: 100, MaxPort: 101},
 	}
 
 	expected := `CONTAINER____MACHINE____COMMAND___________HOSTNAME_______` +
@@ -273,8 +277,10 @@ ________________________________________________________________________________
 		{CloudID: "5", PublicIP: "7.7.7.7", PrivateIP: "1.1.1.1"},
 	}
 	connections = []db.Connection{
-		{ID: 1, From: "public", To: "frompub", MinPort: 80, MaxPort: 80},
-		{ID: 2, From: "public", To: "frompub", MinPort: 100, MaxPort: 101},
+		{ID: 1, From: []string{"public"}, To: []string{"frompub"},
+			MinPort: 80, MaxPort: 80},
+		{ID: 2, From: []string{"public"}, To: []string{"frompub"},
+			MinPort: 100, MaxPort: 101},
 	}
 
 	expected = `CONTAINER____MACHINE____COMMAND____HOSTNAME____STATUS_______` +

--- a/cloud/foreman/foreman.go
+++ b/cloud/foreman/foreman.go
@@ -247,7 +247,7 @@ var newClient = newClientImpl
 
 func (cl clientImpl) getMinion() (pb.MinionConfig, error) {
 	c.Inc("Get Minion")
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
 	cfg, err := cl.GetMinionConfig(ctx, &pb.Request{})
 	if err != nil {
 		c.Inc("Get Minion Error")
@@ -259,7 +259,7 @@ func (cl clientImpl) getMinion() (pb.MinionConfig, error) {
 
 func (cl clientImpl) setMinion(cfg pb.MinionConfig) error {
 	c.Inc("Set Minion")
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
 	_, err := cl.SetMinionConfig(ctx, &cfg)
 	if err != nil {
 		c.Inc("Set Minion Error")

--- a/cloud/join.go
+++ b/cloud/join.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kelda/kelda/cloud/foreman"
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/join"
+	"github.com/kelda/kelda/util/str"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -254,7 +255,7 @@ func (cld cloud) desiredACLs(bp db.Blueprint) map[acl.ACL]struct{} {
 	}
 
 	for _, conn := range bp.Connections {
-		if conn.From == blueprint.PublicInternetLabel {
+		if str.SliceContains(conn.From, blueprint.PublicInternetLabel) {
 			acl := acl.ACL{
 				CidrIP:  "0.0.0.0/0",
 				MinPort: conn.MinPort,

--- a/cloud/join_test.go
+++ b/cloud/join_test.go
@@ -271,8 +271,8 @@ func TestDesiredACLs(t *testing.T) {
 	acls = cld.desiredACLs(db.Blueprint{
 		Blueprint: blueprint.Blueprint{
 			Connections: []blueprint.Connection{{
-				From:    "foo",
-				To:      "bar",
+				From:    []string{"foo"},
+				To:      []string{"bar"},
 				MinPort: 5,
 				MaxPort: 6,
 			}},
@@ -284,8 +284,8 @@ func TestDesiredACLs(t *testing.T) {
 	acls = cld.desiredACLs(db.Blueprint{
 		Blueprint: blueprint.Blueprint{
 			Connections: []blueprint.Connection{{
-				From:    blueprint.PublicInternetLabel,
-				To:      "bar",
+				From:    []string{blueprint.PublicInternetLabel},
+				To:      []string{"bar"},
 				MinPort: 1,
 				MaxPort: 2,
 			}},

--- a/cloud/join_test.go
+++ b/cloud/join_test.go
@@ -125,25 +125,25 @@ func TestPlanUpdates(t *testing.T) {
 		m.PublicIP = "1.2.3.4"
 		view.Commit(m)
 
-		boot, stop, updateIPs := cld.planUpdates(view)
+		res := cld.planUpdates(view)
 		assert.Equal(t, []db.Machine{{
 			Provider: FakeAmazon,
 			Region:   testRegion,
 			DiskSize: 32,
 			Size:     "1",
-			Status:   db.Booting}}, scrubID(boot))
+			Status:   db.Booting}}, scrubID(res.boot))
 		assert.Equal(t, []db.Machine{{
 			Provider: FakeAmazon,
 			Region:   testRegion,
 			Size:     "2",
-			Status:   db.Stopping}}, scrubID(stop))
+			Status:   db.Stopping}}, scrubID(res.terminate))
 		assert.Equal(t, []db.Machine{{
 			Provider:   FakeAmazon,
 			Region:     testRegion,
 			Size:       "3",
 			PublicIP:   "1.2.3.4",
 			FloatingIP: "5.6.7.8",
-			Status:     db.Connected}}, scrubID(updateIPs))
+			Status:     db.Connected}}, scrubID(res.updateIPs))
 
 		return nil
 	})

--- a/db/connection.go
+++ b/db/connection.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"fmt"
+
+	"github.com/kelda/kelda/util/str"
 )
 
 // A Connection allows two hostnames to speak to each other on the port
@@ -9,8 +11,8 @@ import (
 type Connection struct {
 	ID int `json:"-"`
 
-	From    string
-	To      string
+	From    []string
+	To      []string
 	MinPort int
 	MaxPort int
 }
@@ -61,11 +63,13 @@ func (c Connection) String() string {
 func (c Connection) less(r row) bool {
 	o := r.(Connection)
 
+	if cmp := str.SliceCmp(c.From, o.From); cmp != 0 {
+		return cmp < 0
+	} else if cmp := str.SliceCmp(c.To, o.To); cmp != 0 {
+		return cmp < 0
+	}
+
 	switch {
-	case c.From != o.From:
-		return c.From < o.From
-	case c.To != o.To:
-		return c.To < o.To
 	case c.MaxPort != o.MaxPort:
 		return c.MaxPort < o.MaxPort
 	case c.MinPort != o.MinPort:

--- a/db/connection_test.go
+++ b/db/connection_test.go
@@ -15,7 +15,7 @@ func TestConnection(t *testing.T) {
 	conn.Txn(ConnectionTable).Run(func(view Database) error {
 		connection := view.InsertConnection()
 		id = connection.ID
-		connection.From = "foo"
+		connection.From = []string{"foo"}
 		view.Commit(connection)
 		return nil
 	})
@@ -25,18 +25,24 @@ func TestConnection(t *testing.T) {
 	assert.Equal(t, 1, connections.Len())
 
 	connection := connections[0]
-	assert.Equal(t, "foo", connection.From)
+	assert.Equal(t, []string{"foo"}, connection.From)
 	assert.Equal(t, id, connection.getID())
 
 	connection.MaxPort = 3
-	assert.Equal(t, "Connection-1{foo->:0-3}", connection.String())
+	assert.Equal(t, "Connection-1{[foo]->[]:0-3}", connection.String())
 	connection.MaxPort = 0
 
 	assert.Equal(t, connection, connections.Get(0))
 
-	assert.True(t, connection.less(Connection{From: "z"}))
-	assert.True(t, connection.less(Connection{From: "foo", To: "a"}))
-	assert.True(t, connection.less(Connection{From: "foo", MaxPort: 1}))
-	assert.True(t, connection.less(Connection{From: "foo", MinPort: 100}))
-	assert.True(t, connection.less(Connection{From: "foo", ID: id + 1}))
+	assert.True(t, connection.less(Connection{From: []string{"z"}}))
+	assert.True(t, connection.less(Connection{From: []string{"foo"},
+		To: []string{"a"}}))
+	assert.True(t, connection.less(Connection{From: []string{"foo"}, MaxPort: 1}))
+	assert.True(t, connection.less(Connection{From: []string{"foo"}, MinPort: 100}))
+	assert.True(t, connection.less(Connection{From: []string{"foo"}, ID: id + 1}))
+
+	assert.True(t, connection.less(Connection{From: []string{"foo", "bar"}}))
+	assert.True(t, connection.less(Connection{From: []string{"foo"},
+		To: []string{"baz", "qux"}}))
+
 }

--- a/integration-tester/tests/10-network/connection_test.go
+++ b/integration-tester/tests/10-network/connection_test.go
@@ -41,7 +41,9 @@ func newConnectionTester(clnt client.Client) (connectionTester, error) {
 
 	connectionMap := make(map[string][]string)
 	for _, conn := range connections {
-		connectionMap[conn.From] = append(connectionMap[conn.From], conn.To)
+		for _, from := range conn.From {
+			connectionMap[from] = append(connectionMap[from], conn.To...)
+		}
 	}
 
 	return connectionTester{

--- a/integration-tester/tests/outbound-public/outbound_public_test.go
+++ b/integration-tester/tests/outbound-public/outbound_public_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kelda/kelda/blueprint"
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/integration-tester/util"
+	"github.com/kelda/kelda/util/str"
 )
 
 func TestOutboundPublic(t *testing.T) {
@@ -36,9 +37,11 @@ var testHost = fmt.Sprintf("google.com:%d", testPort)
 func test(t *testing.T, containers []db.Container, connections []db.Connection) {
 	connected := map[string]struct{}{}
 	for _, conn := range connections {
-		if conn.To == blueprint.PublicInternetLabel &&
+		if str.SliceContains(conn.To, blueprint.PublicInternetLabel) &&
 			inRange(testPort, conn.MinPort, conn.MaxPort) {
-			connected[conn.From] = struct{}{}
+			for _, from := range conn.From {
+				connected[from] = struct{}{}
+			}
 		}
 	}
 

--- a/integration-tester/util/util.go
+++ b/integration-tester/util/util.go
@@ -13,6 +13,7 @@ import (
 	cliPath "github.com/kelda/kelda/cli/path"
 	tlsIO "github.com/kelda/kelda/connection/tls/io"
 	"github.com/kelda/kelda/db"
+	"github.com/kelda/kelda/util/str"
 )
 
 // GetDefaultDaemonClient gets an API client connected to the daemon on the
@@ -34,9 +35,11 @@ func CheckPublicConnections(t *testing.T, machines []db.Machine,
 	// Map of hostname to its publicly exposed ports.
 	pubConns := map[string][]int{}
 	for _, conn := range connections {
-		if conn.From == "public" {
+		if str.SliceContains(conn.From, "public") {
 			for port := conn.MinPort; port <= conn.MaxPort; port++ {
-				pubConns[conn.To] = append(pubConns[conn.To], port)
+				for _, to := range conn.To {
+					pubConns[to] = append(pubConns[to], port)
+				}
 			}
 		}
 	}

--- a/js/bindings/bindings.js
+++ b/js/bindings/bindings.js
@@ -304,7 +304,7 @@ function vet(infrastructure) {
   });
 
   infrastructure.connections.forEach((conn) => {
-    [conn.from, conn.to].forEach((host) => {
+    conn.from.concat(conn.to).forEach((host) => {
       if (!hostnameMap[host]) {
         throw new Error(`connection ${stringify(conn)} references ` +
                     `an undefined hostname: ${host}`);
@@ -394,10 +394,8 @@ class LoadBalancer {
             'or list of containers and not from a Load Balancer or other object.');
     }
 
-    src.forEach((c) => {
-      this.allowedInboundConnections.push(
-        new Connection(c, boxRange(portRange)));
-    });
+    this.allowedInboundConnections.push(
+      new Connection(src, boxRange(portRange)));
   }
 
   /**
@@ -407,8 +405,8 @@ class LoadBalancer {
    */
   getKeldaConnections() {
     return this.allowedInboundConnections.map(conn => ({
-      from: conn.from.hostname,
-      to: this.name,
+      from: conn.from.map(f => f.hostname),
+      to: [this.name],
       minPort: conn.minPort,
       maxPort: conn.maxPort,
     }));
@@ -1201,10 +1199,8 @@ class Container {
               'list of containers, and not from a LoadBalancer or other object.');
     }
 
-    src.forEach((c) => {
-      this.allowedInboundConnections.push(
-        new Connection(c, boxRange(portRange)));
-    });
+    this.allowedInboundConnections.push(
+      new Connection(src, boxRange(portRange)));
   }
 
   /**
@@ -1263,8 +1259,8 @@ class Container {
 
     this.allowedInboundConnections.forEach((conn) => {
       connections.push({
-        from: conn.from.hostname,
-        to: this.hostname,
+        from: conn.from.map(f => f.hostname),
+        to: [this.hostname],
         minPort: conn.minPort,
         maxPort: conn.maxPort,
       });
@@ -1272,8 +1268,8 @@ class Container {
 
     this.outgoingPublic.forEach((rng) => {
       connections.push({
-        from: this.hostname,
-        to: publicInternetLabel,
+        from: [this.hostname],
+        to: [publicInternetLabel],
         minPort: rng.min,
         maxPort: rng.max,
       });
@@ -1281,8 +1277,8 @@ class Container {
 
     this.incomingPublic.forEach((rng) => {
       connections.push({
-        from: publicInternetLabel,
-        to: this.hostname,
+        from: [publicInternetLabel],
+        to: [this.hostname],
         minPort: rng.min,
         maxPort: rng.max,
       });
@@ -1431,7 +1427,7 @@ class Connection {
    * Creates a Connection.
    * @constructor
    *
-   * @param {string} from - The host from which connections are allowed.
+   * @param {string[]} from - A list of hosts that allow connections.
    * @param {PortRange} ports - The port numbers which are allowed.
    */
   constructor(from, ports) {

--- a/js/bindings/bindingsTest.js
+++ b/js/bindings/bindingsTest.js
@@ -719,8 +719,8 @@ describe('Bindings', () => {
     it('autobox port ranges', () => {
       bar.allowFrom(foo, 80);
       checkConnections([{
-        from: 'foo',
-        to: 'bar',
+        from: ['foo'],
+        to: ['bar'],
         minPort: 80,
         maxPort: 80,
       }]);
@@ -728,8 +728,8 @@ describe('Bindings', () => {
     it('port', () => {
       bar.allowFrom(foo, new b.Port(80));
       checkConnections([{
-        from: 'foo',
-        to: 'bar',
+        from: ['foo'],
+        to: ['bar'],
         minPort: 80,
         maxPort: 80,
       }]);
@@ -737,8 +737,8 @@ describe('Bindings', () => {
     it('port range', () => {
       bar.allowFrom(foo, new b.PortRange(80, 85));
       checkConnections([{
-        from: 'foo',
-        to: 'bar',
+        from: ['foo'],
+        to: ['bar'],
         minPort: 80,
         maxPort: 85,
       }]);
@@ -750,8 +750,8 @@ describe('Bindings', () => {
     it('allow connections to publicInternet', () => {
       b.publicInternet.allowFrom(foo, 80);
       checkConnections([{
-        from: 'foo',
-        to: 'public',
+        from: ['foo'],
+        to: ['public'],
         minPort: 80,
         maxPort: 80,
       }]);
@@ -759,8 +759,8 @@ describe('Bindings', () => {
     it('allow connections from publicInternet', () => {
       foo.allowFrom(b.publicInternet, 80);
       checkConnections([{
-        from: 'public',
-        to: 'foo',
+        from: ['public'],
+        to: ['foo'],
         minPort: 80,
         maxPort: 80,
       }]);
@@ -768,8 +768,8 @@ describe('Bindings', () => {
     it('connect to LoadBalancer', () => {
       fooLoadBalancer.allowFrom(bar, 80);
       checkConnections([{
-        from: 'bar',
-        to: 'fooLoadBalancer',
+        from: ['bar'],
+        to: ['fooLoadBalancer'],
         minPort: 80,
         maxPort: 80,
       }]);
@@ -822,50 +822,46 @@ describe('Bindings', () => {
     it('both src and dst are lists', () => {
       b.allow(quxQuuzGroup, fooBarGroup, 80);
       checkConnections([
-        { from: 'qux', to: 'foo', minPort: 80, maxPort: 80 },
-        { from: 'qux', to: 'bar', minPort: 80, maxPort: 80 },
-        { from: 'quuz', to: 'foo', minPort: 80, maxPort: 80 },
-        { from: 'quuz', to: 'bar', minPort: 80, maxPort: 80 },
+        { from: ['qux', 'quuz'], to: ['foo'], minPort: 80, maxPort: 80 },
+        { from: ['qux', 'quuz'], to: ['bar'], minPort: 80, maxPort: 80 },
       ]);
     });
 
     it('dst is a list', () => {
       b.allow(qux, fooBarGroup, 80);
       checkConnections([
-        { from: 'qux', to: 'foo', minPort: 80, maxPort: 80 },
-        { from: 'qux', to: 'bar', minPort: 80, maxPort: 80 },
+        { from: ['qux'], to: ['foo'], minPort: 80, maxPort: 80 },
+        { from: ['qux'], to: ['bar'], minPort: 80, maxPort: 80 },
       ]);
     });
 
     it('src is a list', () => {
       b.allow(fooBarGroup, qux, 80);
       checkConnections([
-        { from: 'foo', to: 'qux', minPort: 80, maxPort: 80 },
-        { from: 'bar', to: 'qux', minPort: 80, maxPort: 80 },
+        { from: ['foo', 'bar'], to: ['qux'], minPort: 80, maxPort: 80 },
       ]);
     });
 
     it('src is public', () => {
       b.allow(b.publicInternet, fooBarGroup, 80);
       checkConnections([
-        { from: 'public', to: 'foo', minPort: 80, maxPort: 80 },
-        { from: 'public', to: 'bar', minPort: 80, maxPort: 80 },
+        { from: ['public'], to: ['foo'], minPort: 80, maxPort: 80 },
+        { from: ['public'], to: ['bar'], minPort: 80, maxPort: 80 },
       ]);
     });
 
     it('dst is public', () => {
       b.allow(fooBarGroup, b.publicInternet, 80);
       checkConnections([
-        { from: 'foo', to: 'public', minPort: 80, maxPort: 80 },
-        { from: 'bar', to: 'public', minPort: 80, maxPort: 80 },
+        { from: ['foo'], to: ['public'], minPort: 80, maxPort: 80 },
+        { from: ['bar'], to: ['public'], minPort: 80, maxPort: 80 },
       ]);
     });
 
     it('dst is a LoadBalancer', () => {
       b.allow(fooBarGroup, lb, 80);
       checkConnections([
-        { from: 'foo', to: 'serv', minPort: 80, maxPort: 80 },
-        { from: 'bar', to: 'serv', minPort: 80, maxPort: 80 },
+        { from: ['foo', 'bar'], to: ['serv'], minPort: 80, maxPort: 80 },
       ]);
     });
   });
@@ -886,8 +882,8 @@ describe('Bindings', () => {
     it('connect from undeployed container', () => {
       foo.allowFrom(new b.Container('baz', 'image'), 80);
       expect(deploy).to.throw(
-        'connection {"from":"baz","maxPort":80,"minPort":80,' +
-                '"to":"foo"} references an undefined hostname: baz');
+        'connection {"from":["baz"],"maxPort":80,"minPort":80,' +
+                '"to":["foo"]} references an undefined hostname: baz');
     });
     it('duplicate image', () => {
       (new b.Container('host', new b.Image('img', 'dk'))).deploy(infra);

--- a/minion/etcd/connection.go
+++ b/minion/etcd/connection.go
@@ -53,8 +53,8 @@ func runConnectionOnce(conn db.Conn, store Store) error {
 func joinConnections(view db.Database, etcdConns []db.Connection) {
 	key := func(iface interface{}) interface{} {
 		conn := iface.(db.Connection)
-		conn.ID = 0
-		return conn
+		return fmt.Sprintf("%s %s %d %d",
+			conn.From, conn.To, conn.MinPort, conn.MaxPort)
 	}
 
 	_, connIfaces, etcdConnIfaces := join.HashJoin(

--- a/minion/etcd/connection_test.go
+++ b/minion/etcd/connection_test.go
@@ -25,8 +25,8 @@ func TestRunConnectionOnce(t *testing.T) {
 		view.Commit(etcd)
 
 		conn := view.InsertConnection()
-		conn.From = "a"
-		conn.To = "b"
+		conn.From = []string{"a"}
+		conn.To = []string{"b"}
 		conn.MinPort = 80
 		conn.MaxPort = 8080
 		view.Commit(conn)
@@ -41,8 +41,12 @@ func TestRunConnectionOnce(t *testing.T) {
 
 	expStr := `[
     {
-        "From": "a",
-        "To": "b",
+        "From": [
+            "a"
+        ],
+        "To": [
+            "b"
+        ],
         "MinPort": 80,
         "MaxPort": 8080
     }
@@ -55,8 +59,8 @@ func TestRunConnectionOnce(t *testing.T) {
 		view.Commit(etcd)
 
 		conn := view.SelectFromConnection(nil)[0]
-		conn.From = "1"
-		conn.To = "2"
+		conn.From = []string{"1"}
+		conn.To = []string{"2"}
 		conn.MinPort = 3
 		conn.MaxPort = 4
 		view.Commit(conn)
@@ -69,6 +73,6 @@ func TestRunConnectionOnce(t *testing.T) {
 	conns := conn.SelectFromConnection(nil)
 	assert.Len(t, conns, 1)
 	conns[0].ID = 0
-	assert.Equal(t, db.Connection{From: "a", To: "b", MinPort: 80, MaxPort: 8080},
-		conns[0])
+	assert.Equal(t, db.Connection{From: []string{"a"}, To: []string{"b"},
+		MinPort: 80, MaxPort: 8080}, conns[0])
 }

--- a/minion/etcd/container.go
+++ b/minion/etcd/container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/join"
 	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -143,5 +144,5 @@ func containerValueMapKey(x map[string]blueprint.ContainerValue) string {
 	for key, val := range x {
 		m[key] = fmt.Sprintf("%+v", val)
 	}
-	return util.MapAsString(m)
+	return str.MapAsString(m)
 }

--- a/minion/network/acl_test.go
+++ b/minion/network/acl_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kelda/kelda/blueprint"
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/minion/ovsdb"
 	"github.com/kelda/kelda/minion/ovsdb/mocks"
@@ -12,40 +11,141 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestUpdateACLs(t *testing.T) {
+func TestResolveConenctions(t *testing.T) {
+	t.Parallel()
+
+	connections, addressSets := resolveConnections([]db.Connection{{
+		From: []string{"public"},
+		To:   []string{"a"},
+	}, {
+		From: []string{"a"},
+		To:   []string{"badHostname"},
+	}, {
+		From:    []string{"a", "b"},
+		To:      []string{"c"},
+		MinPort: 1,
+		MaxPort: 2,
+	}, {
+		From:    []string{"a", "b", "c"},
+		To:      []string{"a", "b"},
+		MinPort: 3,
+		MaxPort: 4,
+	}, {
+		From:    []string{"a"},
+		To:      []string{"a", "c"},
+		MinPort: 5,
+		MaxPort: 6,
+	}, {
+		From:    []string{"a", "c"},
+		To:      []string{"a", "b", "c"},
+		MinPort: 7,
+		MaxPort: 8,
+	}}, map[string]string{
+		"a": "1.1.1.1",
+		"b": "2.2.2.2",
+		"c": "3.3.3.3",
+	})
+
+	assert.Equal(t, []connection{{
+		from: "$sha886f76b8da8aa4cb490c3c9e7c8e6" +
+			"df5add0c795ed90b460f0b7765bba4d2bc3",
+		to:      "3.3.3.3",
+		minPort: 1,
+		maxPort: 2,
+	}, {
+		from: "$shad318437b8c796a3a7470bbc8f8457" +
+			"41f4e9bc7478b32191a1f8e2bb215a2bef8",
+		to: "$sha886f76b8da8aa4cb490c3c9e7c8e6" +
+			"df5add0c795ed90b460f0b7765bba4d2bc3",
+		minPort: 3,
+		maxPort: 4,
+	}, {
+		from: "1.1.1.1",
+		to: "$sha7d3647dab65e8fe823c7b3ffdd738" +
+			"59e88450368c683c0cbcdb1c8d7b348a9d9",
+		minPort: 5,
+		maxPort: 6,
+	}, {
+		from: "$sha7d3647dab65e8fe823c7b3ffdd738" +
+			"59e88450368c683c0cbcdb1c8d7b348a9d9",
+		to: "$shad318437b8c796a3a7470bbc8f8457" +
+			"41f4e9bc7478b32191a1f8e2bb215a2bef8",
+		minPort: 7,
+		maxPort: 8,
+	}}, connections)
+
+	exp := map[string][]string{
+		"sha886f76b8da8aa4cb490c3c9e7c8e6df5add0c795ed90b460f0b7" +
+			"765bba4d2bc3": {"1.1.1.1", "2.2.2.2"},
+		"shad318437b8c796a3a7470bbc8f845741f4e9bc7478b32191a1f8e" +
+			"2bb215a2bef8": {"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+		"sha7d3647dab65e8fe823c7b3ffdd73859e88450368c683c0cbcdb1" +
+			"c8d7b348a9d9": {"1.1.1.1", "3.3.3.3"},
+	}
+
+	actual := map[string][]string{}
+	for _, as := range addressSets {
+		if _, ok := actual[as.Name]; ok {
+			t.Errorf("Duplicate address set %s", as)
+		}
+		actual[as.Name] = as.Addresses
+	}
+
+	assert.Equal(t, exp, actual)
+
+}
+
+func TestSyncAddressSets(t *testing.T) {
+	t.Parallel()
+
+	client := new(mocks.Client)
+	client.On("ListAddressSets").Return(nil, assert.AnError).Once()
+	syncAddressSets(client, nil)
+	client.AssertCalled(t, "ListAddressSets")
+
+	client.On("ListAddressSets").Return([]ovsdb.AddressSet{{Name: "old"}}, nil)
+
+	client.On("DeleteAddressSets", []ovsdb.AddressSet{{Name: "old"}}).Return(
+		assert.AnError).Once()
+	client.On("CreateAddressSets", []ovsdb.AddressSet{{Name: "new"}}).Return(
+		assert.AnError).Once()
+	syncAddressSets(client, []ovsdb.AddressSet{{Name: "new"}})
+	client.AssertExpectations(t)
+
+	client.On("DeleteAddressSets", []ovsdb.AddressSet{{Name: "old"}}).Return(nil)
+	client.On("CreateAddressSets", []ovsdb.AddressSet{{Name: "new"}}).Return(nil)
+	syncAddressSets(client, []ovsdb.AddressSet{{Name: "new"}})
+	client.AssertExpectations(t)
+}
+
+func TestSyncACLs(t *testing.T) {
 	t.Parallel()
 	client := new(mocks.Client)
 
 	anErr := errors.New("err")
 	client.On("ListACLs").Return(nil, anErr).Once()
-	updateACLs(client, nil, nil)
+	syncACLs(client, nil)
 	client.AssertCalled(t, "ListACLs")
 
-	conns := []db.Connection{
+	conns := []connection{
 		{
-			From:    blueprint.PublicInternetLabel,
-			To:      "ignoreme",
-			MinPort: 80,
-			MaxPort: 80,
+			from:    "8.8.8.8",
+			to:      "9.9.9.9",
+			minPort: 80,
+			maxPort: 80,
 		}, {
-			From:    "b",
-			To:      "c",
-			MinPort: 80,
-			MaxPort: 80,
-		}, {
-			From:    "b",
-			To:      "c",
-			MinPort: 8080,
-			MaxPort: 8080,
+			from:    "8.8.8.8",
+			to:      "9.9.9.9",
+			minPort: 8080,
+			maxPort: 8080,
 		},
 	}
-	hostnameToIP := map[string]string{"b": "8.8.8.8", "c": "9.9.9.9"}
 	core := ovsdb.ACLCore{Match: "a"}
 	client.On("ListACLs").Return([]ovsdb.ACL{{Core: core}}, nil)
 
 	client.On("CreateACLs", "kelda", mock.Anything).Return(nil).Once()
 	client.On("DeleteACLs", mock.Anything, mock.Anything).Return(anErr).Once()
-	updateACLs(client, conns, hostnameToIP)
+	syncACLs(client, conns)
 
 	// The order to CreateACLs is not deterministic, so we have to check that it
 	// was called properly after the fact.
@@ -80,22 +180,22 @@ func TestUpdateACLs(t *testing.T) {
 	}, {
 		Priority:  1,
 		Direction: "from-lport",
-		Match:     getMatchString("8.8.8.8", "9.9.9.9", 80, 80),
+		Match:     getMatchString(connection{"8.8.8.8", "9.9.9.9", 80, 80}),
 		Action:    "allow",
 	}, {
 		Priority:  1,
 		Direction: "to-lport",
-		Match:     getMatchString("8.8.8.8", "9.9.9.9", 80, 80),
+		Match:     getMatchString(connection{"8.8.8.8", "9.9.9.9", 80, 80}),
 		Action:    "allow",
 	}, {
 		Priority:  1,
 		Direction: "from-lport",
-		Match:     getMatchString("8.8.8.8", "9.9.9.9", 8080, 8080),
+		Match:     getMatchString(connection{"8.8.8.8", "9.9.9.9", 8080, 8080}),
 		Action:    "allow",
 	}, {
 		Priority:  1,
 		Direction: "to-lport",
-		Match:     getMatchString("8.8.8.8", "9.9.9.9", 8080, 8080),
+		Match:     getMatchString(connection{"8.8.8.8", "9.9.9.9", 8080, 8080}),
 		Action:    "allow",
 	}}
 
@@ -108,6 +208,6 @@ func TestUpdateACLs(t *testing.T) {
 	client.On("CreateACLs", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(anErr)
 	client.On("DeleteACLs", mock.Anything, mock.Anything).Return(anErr).Once()
-	updateACLs(client, conns, hostnameToIP)
+	syncACLs(client, conns)
 	client.AssertCalled(t, "ListACLs")
 }

--- a/minion/network/load_balancer.go
+++ b/minion/network/load_balancer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kelda/kelda/join"
 	"github.com/kelda/kelda/minion/ipdef"
 	"github.com/kelda/kelda/minion/ovsdb"
-	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 )
 
 /*
@@ -83,7 +83,7 @@ func updateLoadBalancerIPs(client ovsdb.Client, loadBalancers []db.LoadBalancer,
 		lb := intf.(ovsdb.LoadBalancer)
 		return struct{ Name, VIPs string }{
 			Name: lb.Name,
-			VIPs: util.MapAsString(lb.VIPs),
+			VIPs: str.MapAsString(lb.VIPs),
 		}
 	}
 	_, toAdd, toRemove := join.HashJoin(loadBalancerSlice(target),

--- a/minion/network/nat.go
+++ b/minion/network/nat.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/join"
 	"github.com/kelda/kelda/minion/nl"
-	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 
 	"github.com/coreos/go-iptables/iptables"
 	log "github.com/sirupsen/logrus"
@@ -138,7 +138,7 @@ func ruleKey(intf interface{}) interface{} {
 		opts[flagName] = flagVal
 	}
 
-	return util.MapAsString(opts)
+	return str.MapAsString(opts)
 }
 
 func syncChain(ipt IPTables, table, chain string, target []string) error {

--- a/minion/network/nat_test.go
+++ b/minion/network/nat_test.go
@@ -66,18 +66,18 @@ func TestPreroutingRules(t *testing.T) {
 
 	connections := []db.Connection{
 		{
-			From:    blueprint.PublicInternetLabel,
-			To:      "red",
+			From:    []string{blueprint.PublicInternetLabel},
+			To:      []string{"red"},
 			MinPort: 80,
 		},
 		{
-			From:    blueprint.PublicInternetLabel,
-			To:      "purple",
+			From:    []string{blueprint.PublicInternetLabel},
+			To:      []string{"purple"},
 			MinPort: 81,
 		},
 		{
-			From:    "yellow",
-			To:      blueprint.PublicInternetLabel,
+			From:    []string{"yellow"},
+			To:      []string{blueprint.PublicInternetLabel},
 			MinPort: 80,
 		},
 	}
@@ -108,13 +108,13 @@ func TestPostroutingRules(t *testing.T) {
 
 	connections := []db.Connection{
 		{
-			From:    "red",
-			To:      blueprint.PublicInternetLabel,
+			From:    []string{"red"},
+			To:      []string{blueprint.PublicInternetLabel},
 			MinPort: 80,
 		},
 		{
-			From:    "purple",
-			To:      blueprint.PublicInternetLabel,
+			From:    []string{"purple"},
+			To:      []string{blueprint.PublicInternetLabel},
 			MinPort: 81,
 		},
 	}

--- a/minion/network/route.go
+++ b/minion/network/route.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/minion/ipdef"
 	"github.com/kelda/kelda/minion/nl"
-	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 )
 
 var subnetC = counter.New("Subnet Sync")
@@ -51,7 +51,7 @@ func writeSubnetsOnce(conn db.Conn) error {
 
 	conn.Txn(db.MinionTable).Run(func(view db.Database) error {
 		self := view.MinionSelf()
-		if !util.StrSliceEqual(subnets, self.HostSubnets) {
+		if !str.SliceEq(subnets, self.HostSubnets) {
 			subnetC.Inc("Update subnets")
 			self.HostSubnets = subnets
 			view.Commit(self)

--- a/minion/ovsdb/mocks/Client.go
+++ b/minion/ovsdb/mocks/Client.go
@@ -24,6 +24,20 @@ func (_m *Client) CreateACLs(lswitch string, acls []ovsdb.ACLCore) error {
 	return r0
 }
 
+// CreateAddressSets provides a mock function with given fields: _a0
+func (_m *Client) CreateAddressSets(_a0 []ovsdb.AddressSet) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]ovsdb.AddressSet) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateLoadBalancer provides a mock function with given fields: lswitch, name, vips
 func (_m *Client) CreateLoadBalancer(lswitch string, name string, vips map[string]string) error {
 	ret := _m.Called(lswitch, name, vips)
@@ -94,13 +108,27 @@ func (_m *Client) CreateSwitchPort(lswitch string, lport ovsdb.SwitchPort) error
 	return r0
 }
 
-// DeleteACLs provides a mock function with given fields: lswitch, ovsdbACL
-func (_m *Client) DeleteACLs(lswitch string, ovsdbACL []ovsdb.ACL) error {
-	ret := _m.Called(lswitch, ovsdbACL)
+// DeleteACLs provides a mock function with given fields: lswitch, acls
+func (_m *Client) DeleteACLs(lswitch string, acls []ovsdb.ACL) error {
+	ret := _m.Called(lswitch, acls)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, []ovsdb.ACL) error); ok {
-		r0 = rf(lswitch, ovsdbACL)
+		r0 = rf(lswitch, acls)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteAddressSets provides a mock function with given fields: _a0
+func (_m *Client) DeleteAddressSets(_a0 []ovsdb.AddressSet) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]ovsdb.AddressSet) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -165,6 +193,29 @@ func (_m *Client) ListACLs() ([]ovsdb.ACL, error) {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ovsdb.ACL)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListAddressSets provides a mock function with given fields:
+func (_m *Client) ListAddressSets() ([]ovsdb.AddressSet, error) {
+	ret := _m.Called()
+
+	var r0 []ovsdb.AddressSet
+	if rf, ok := ret.Get(0).(func() []ovsdb.AddressSet); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ovsdb.AddressSet)
 		}
 	}
 

--- a/minion/scheduler/master.go
+++ b/minion/scheduler/master.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/kelda/kelda/db"
-	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -256,7 +256,7 @@ func (s dbcSlice) Less(i, j int) bool {
 	switch {
 	case s[i].Image != s[j].Image:
 		return s[i].Image < s[j].Image
-	case !util.StrSliceEqual(s[i].Command, s[j].Command):
+	case !str.SliceEq(s[i].Command, s[j].Command):
 		return fmt.Sprintf("%s", s[i].Command) < fmt.Sprintf("%s", s[j].Command)
 	default:
 		return s[i].BlueprintID < s[j].BlueprintID

--- a/minion/scheduler/worker.go
+++ b/minion/scheduler/worker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kelda/kelda/minion/network/openflow"
 	"github.com/kelda/kelda/minion/network/plugin"
 	"github.com/kelda/kelda/minion/vault"
-	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -243,8 +243,8 @@ func syncJoinScore(left, right interface{}) int {
 	cmd1 := dkc.Args
 	cmd2 := append([]string{dkc.Path}, dkc.Args...)
 	if len(dbc.Command) != 0 &&
-		!util.StrSliceEqual(dbc.Command, cmd1) &&
-		!util.StrSliceEqual(dbc.Command, cmd2) {
+		!str.SliceEq(dbc.Command, cmd1) &&
+		!str.SliceEq(dbc.Command, cmd2) {
 		return -1
 	}
 
@@ -252,7 +252,7 @@ func syncJoinScore(left, right interface{}) int {
 }
 
 func filesHash(filepathToContent map[string]string) string {
-	toHash := util.MapAsString(filepathToContent)
+	toHash := str.MapAsString(filepathToContent)
 	return fmt.Sprintf("%x", sha1.Sum([]byte(toHash)))
 }
 

--- a/minion/scheduler/worker.go
+++ b/minion/scheduler/worker.go
@@ -281,26 +281,30 @@ func openflowContainers(dbcs []db.Container,
 	fromPubPorts := map[string][]int{}
 	toPubPorts := map[string][]int{}
 	for _, conn := range conns {
-		if conn.From != blueprint.PublicInternetLabel &&
-			conn.To != blueprint.PublicInternetLabel {
-			continue
-		}
+		for _, from := range conn.From {
+			for _, to := range conn.To {
+				if from != blueprint.PublicInternetLabel &&
+					to != blueprint.PublicInternetLabel {
+					continue
+				}
 
-		if conn.MinPort != conn.MaxPort {
-			c.Inc("Unsupported Public Port Range")
-			log.WithField("connection", conn).Debug(
-				"Unsupported Public Port Range")
-			continue
-		}
+				if conn.MinPort != conn.MaxPort {
+					c.Inc("Unsupported Public Port Range")
+					log.WithField("connection", conn).Debug(
+						"Unsupported Public Port Range")
+					continue
+				}
 
-		if conn.From == blueprint.PublicInternetLabel {
-			fromPubPorts[conn.To] = append(fromPubPorts[conn.To],
-				conn.MinPort)
-		}
+				if from == blueprint.PublicInternetLabel {
+					fromPubPorts[to] = append(fromPubPorts[to],
+						conn.MinPort)
+				}
 
-		if conn.To == blueprint.PublicInternetLabel {
-			toPubPorts[conn.From] = append(toPubPorts[conn.From],
-				conn.MinPort)
+				if to == blueprint.PublicInternetLabel {
+					toPubPorts[from] = append(toPubPorts[from],
+						conn.MinPort)
+				}
+			}
 		}
 	}
 

--- a/minion/scheduler/worker_test.go
+++ b/minion/scheduler/worker_test.go
@@ -339,9 +339,12 @@ func TestSyncJoinScore(t *testing.T) {
 func TestOpenFlowContainers(t *testing.T) {
 	conns := []db.Connection{
 		{MinPort: 1, MaxPort: 1000},
-		{MinPort: 2, MaxPort: 2, From: blueprint.PublicInternetLabel, To: "red"},
-		{MinPort: 3, MaxPort: 3, To: blueprint.PublicInternetLabel, From: "red"},
-		{MinPort: 4, MaxPort: 4, To: blueprint.PublicInternetLabel, From: "blue"}}
+		{MinPort: 2, MaxPort: 2, From: []string{blueprint.PublicInternetLabel},
+			To: []string{"red"}},
+		{MinPort: 3, MaxPort: 3, To: []string{blueprint.PublicInternetLabel},
+			From: []string{"red"}},
+		{MinPort: 4, MaxPort: 4, To: []string{blueprint.PublicInternetLabel},
+			From: []string{"blue"}}}
 
 	res := openflowContainers([]db.Container{
 		{EndpointID: "f", IP: "1.2.3.4", Hostname: "red"}},

--- a/minion/supervisor/master.go
+++ b/minion/supervisor/master.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kelda/kelda/db"
 	"github.com/kelda/kelda/minion/supervisor/images"
 	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 )
 
 func runMaster() {
@@ -35,7 +36,7 @@ func runMasterOnce() {
 	etcdIPs := etcdRow.EtcdIPs
 	leader := etcdRow.Leader
 
-	if oldIP != IP || !util.StrSliceEqual(oldEtcdIPs, etcdIPs) {
+	if oldIP != IP || !str.SliceEq(oldEtcdIPs, etcdIPs) {
 		c.Inc("Reset Etcd")
 		Remove(images.Etcd)
 	}

--- a/minion/supervisor/worker.go
+++ b/minion/supervisor/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kelda/kelda/minion/nl"
 	"github.com/kelda/kelda/minion/supervisor/images"
 	"github.com/kelda/kelda/util"
+	"github.com/kelda/kelda/util/str"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -64,7 +65,7 @@ func runWorkerOnce() {
 	leaderIP := etcdRow.LeaderIP
 	IP := minion.PrivateIP
 
-	if !util.StrSliceEqual(oldEtcdIPs, etcdIPs) {
+	if !str.SliceEq(oldEtcdIPs, etcdIPs) {
 		c.Inc("Reset Etcd")
 		Remove(images.Etcd)
 	}

--- a/util/str/str.go
+++ b/util/str/str.go
@@ -1,0 +1,75 @@
+package str
+
+import (
+	"fmt"
+	"sort"
+)
+
+// SliceFilterOut returns a new slice that omits all instances of `item`.
+func SliceFilterOut(slice []string, item string) []string {
+	var result []string
+	for _, s := range slice {
+		if s != item {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// SliceContains returns true if `item` is in `slice`.
+func SliceContains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// SliceEq returns true of the string slices 'x' and 'y' are identical.
+func SliceEq(x, y []string) bool {
+	return SliceCmp(x, y) == 0
+}
+
+// SliceCmp applies an arbitrary ordering to slices of strings.  Returns -1 if x < y, 1
+// if x > y, 0 otherwise.
+func SliceCmp(x, y []string) int {
+	if len(x) < len(y) {
+		return -1
+	} else if len(x) > len(y) {
+		return 1
+	}
+
+	for i, v := range x {
+		if v < y[i] {
+			return -1
+		} else if v > y[i] {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+// MapEq returns true if the string->string maps 'x' and 'y' are equal.
+func MapEq(x, y map[string]string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for k, v := range x {
+		if yVal, ok := y[k]; !ok || v != yVal {
+			return false
+		}
+	}
+	return true
+}
+
+// MapAsString creates a deterministic string representing the given map.
+func MapAsString(m map[string]string) string {
+	var strs []string
+	for k, v := range m {
+		strs = append(strs, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Sort(sort.StringSlice(strs))
+	return fmt.Sprintf("%v", strs)
+}

--- a/util/str/str_test.go
+++ b/util/str/str_test.go
@@ -1,0 +1,78 @@
+package str
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSliceFilter(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, SliceFilterOut([]string{"a", "b", "a"}, "a"), []string{"b"})
+	assert.Equal(t, SliceFilterOut([]string{"a", "b"}, "c"), []string{"a", "b"})
+}
+
+func TestSliceContains(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, SliceContains([]string{"b", "a"}, "a"))
+	assert.False(t, SliceContains([]string{"b", "a"}, "c"))
+}
+
+func TestSliceCmp(t *testing.T) {
+	t.Parallel()
+
+	x := []string{}
+	y := []string{}
+
+	assert.Zero(t, SliceCmp(x, y))
+	assert.True(t, SliceEq(x, y))
+
+	x = append(x, "1")
+	assert.Equal(t, 1, SliceCmp(x, y))
+	assert.Equal(t, -1, SliceCmp(y, x))
+	assert.False(t, SliceEq(x, y))
+
+	y = append(y, "1")
+	assert.Zero(t, SliceCmp(x, y))
+	assert.True(t, SliceEq(x, y))
+
+	x = append(x, "a")
+	y = append(y, "b")
+	assert.Equal(t, -1, SliceCmp(x, y))
+	assert.Equal(t, 1, SliceCmp(y, x))
+	assert.False(t, SliceEq(x, y))
+}
+
+func TestMapEqual(t *testing.T) {
+	t.Parallel()
+
+	a := map[string]string{}
+	b := map[string]string{}
+
+	assert.True(t, MapEq(a, b))
+
+	a["1"] = "1"
+	assert.False(t, MapEq(a, b))
+
+	b["1"] = a["1"]
+	assert.True(t, MapEq(a, b))
+
+	b["1"] = "2"
+	assert.False(t, MapEq(a, b))
+}
+
+func TestMapString(t *testing.T) {
+	t.Parallel()
+
+	// Run the tests multiple times to test determinism.
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, "[a=1 b=2]", MapAsString(
+			map[string]string{"a": "1", "b": "2"}))
+
+		// Nil and empty maps are the same.
+		assert.Equal(t, "[]", MapAsString(nil))
+		assert.Equal(t, "[]", MapAsString(map[string]string{}))
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -148,44 +147,6 @@ func Walk(root string, walkFn filepath.WalkFunc) error {
 		Fs: AppFs,
 	}
 	return afero.Walk(a, root, walkFn)
-}
-
-// StrSliceEqual returns true of the string slices 'x' and 'y' are identical.
-func StrSliceEqual(x, y []string) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	for i, v := range x {
-		if v != y[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// StrStrMapEqual returns true of the string->string maps 'x' and 'y' are equal.
-func StrStrMapEqual(x, y map[string]string) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	for k, v := range x {
-		if yVal, ok := y[k]; !ok {
-			return false
-		} else if v != yVal {
-			return false
-		}
-	}
-	return true
-}
-
-// MapAsString creates a deterministic string representing the given map.
-func MapAsString(m map[string]string) string {
-	var strs []string
-	for k, v := range m {
-		strs = append(strs, fmt.Sprintf("%s=%s", k, v))
-	}
-	sort.Sort(sort.StringSlice(strs))
-	return fmt.Sprintf("%v", strs)
 }
 
 // After returns whether the current time is after t. It is stored in a variable so it

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -68,18 +68,6 @@ func TestWaitFor(t *testing.T) {
 	assert.EqualError(t, err, "timed out")
 }
 
-func TestMapAsString(t *testing.T) {
-	// Run the tests multiple times to test determinism.
-	for i := 0; i < 10; i++ {
-		assert.Equal(t, "[a=1 b=2]", MapAsString(
-			map[string]string{"a": "1", "b": "2"}))
-
-		// Nil and empty maps are the same.
-		assert.Equal(t, "[]", MapAsString(nil))
-		assert.Equal(t, "[]", MapAsString(map[string]string{}))
-	}
-}
-
 func TestJoinNotifiers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
As spark scaled, the number of ACLs that OVN had to process grew at O(n^2)
as the number of workers grew.  At a scale of 64 nodes this would cause OVN
to spend several minutes processing ACLs before the network would work
properly.

This patch dramatically reduces the number of ACLs by adding support for
address sets to the Kelda Daemon.  Address sets allow ACLs to be express
groups of IP addresses, instead of requiring them to be exploded out into a
separate ACL per IP.

This patch adds full support for address sets to the deployment engine, and
partial support to the Javascript bindings.  Even with partial support for
address sets, ACLs are no longer a bottleneck when running Spark.  However,
full support will need to be added later if we want to scale to large
numbers of containers.