### PR TITLE
cloud: Don't assign the role on booting machines

### DIFF
--- a/cloud/join.go
+++ b/cloud/join.go
@@ -146,9 +146,15 @@ func (cld cloud) planUpdates(view db.Database) joinResult {
 		dbm := view.InsertMachine()
 		bpm.ID = dbm.ID
 		bpm.Status = db.Booting
-		view.Commit(bpm)
 
 		res.boot = append(res.boot, bpm)
+
+		// Don't bother assigning the role to the database, as the foreman will
+		// just unassign it in the next run loop.  We can't be sure which machine
+		// in the database gets which role until we actually connect to it
+		// anyways.
+		bpm.Role = db.None
+		view.Commit(bpm)
 	}
 
 	return res


### PR DESCRIPTION
Before this patch, the cloud code would write a booting machine to the
database with a role, and then immediately unset that role in the next
run loop.  Not only is this a bit awkward, it causes problems in some
future patches.