### PR TITLE
digitalocean: Cache List() calls

### DIFF
--- a/cloud/digitalocean/client/client.go
+++ b/cloud/digitalocean/client/client.go
@@ -16,7 +16,7 @@ type Client interface {
 		[]godo.Droplet, *godo.Response, error)
 	DeleteDroplet(int) (*godo.Response, error)
 	GetDroplet(int) (*godo.Droplet, *godo.Response, error)
-	ListDroplets(*godo.ListOptions, string) ([]godo.Droplet, *godo.Response, error)
+	ListDroplets(*godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
 
 	CreateTag(string) (*godo.Tag, *godo.Response, error)
 
@@ -58,10 +58,10 @@ func (client client) GetDroplet(id int) (*godo.Droplet, *godo.Response, error) {
 	return client.droplets.Get(context.Background(), id)
 }
 
-func (client client) ListDroplets(opt *godo.ListOptions, tag string) ([]godo.Droplet,
+func (client client) ListDroplets(opt *godo.ListOptions) ([]godo.Droplet,
 	*godo.Response, error) {
 	c.Inc("List Droplets")
-	return client.droplets.ListByTag(context.Background(), tag, opt)
+	return client.droplets.List(context.Background(), opt)
 }
 
 func (client client) CreateTag(name string) (*godo.Tag, *godo.Response, error) {

--- a/cloud/digitalocean/client/client_test.go
+++ b/cloud/digitalocean/client/client_test.go
@@ -28,9 +28,9 @@ func TestError(t *testing.T) {
 	_, _, err = c.GetDroplet(3)
 	assert.EqualError(t, err, "Get https://api.digitalocean.com/v2/droplets/3: test")
 
-	_, _, err = c.ListDroplets(&godo.ListOptions{}, "tag")
+	_, _, err = c.ListDroplets(&godo.ListOptions{})
 	assert.EqualError(t, err,
-		"Get https://api.digitalocean.com/v2/droplets?tag_name=tag: test")
+		"Get https://api.digitalocean.com/v2/droplets: test")
 
 	_, _, err = c.ListFloatingIPs(&godo.ListOptions{})
 	assert.EqualError(t, err,

--- a/cloud/digitalocean/client/mocks/Client.go
+++ b/cloud/digitalocean/client/mocks/Client.go
@@ -239,13 +239,13 @@ func (_m *Client) GetDroplet(_a0 int) (*godo.Droplet, *godo.Response, error) {
 	return r0, r1, r2
 }
 
-// ListDroplets provides a mock function with given fields: _a0, _a1
-func (_m *Client) ListDroplets(_a0 *godo.ListOptions, _a1 string) ([]godo.Droplet, *godo.Response, error) {
-	ret := _m.Called(_a0, _a1)
+// ListDroplets provides a mock function with given fields: _a0
+func (_m *Client) ListDroplets(_a0 *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+	ret := _m.Called(_a0)
 
 	var r0 []godo.Droplet
-	if rf, ok := ret.Get(0).(func(*godo.ListOptions, string) []godo.Droplet); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(*godo.ListOptions) []godo.Droplet); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]godo.Droplet)
@@ -253,8 +253,8 @@ func (_m *Client) ListDroplets(_a0 *godo.ListOptions, _a1 string) ([]godo.Drople
 	}
 
 	var r1 *godo.Response
-	if rf, ok := ret.Get(1).(func(*godo.ListOptions, string) *godo.Response); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(*godo.ListOptions) *godo.Response); ok {
+		r1 = rf(_a0)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*godo.Response)
@@ -262,8 +262,8 @@ func (_m *Client) ListDroplets(_a0 *godo.ListOptions, _a1 string) ([]godo.Drople
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(*godo.ListOptions, string) error); ok {
-		r2 = rf(_a0, _a1)
+	if rf, ok := ret.Get(2).(func(*godo.ListOptions) error); ok {
+		r2 = rf(_a0)
 	} else {
 		r2 = ret.Error(2)
 	}


### PR DESCRIPTION
Digital Ocean has a rather aggressive API request limit that we're
hitting in integration tests.  Part of the problem, is that the API is
global, serving all regions, rather than segregated per region as it
is in other cloud providers.  This means that instead of making a
single List() call that could request all droplets, we were making a
list call per region, artificially inflating our requests per second.
This patch solves the issue by caching the result of a List() call for
1 second, allowing it to be reused by other regions without making API
requests.